### PR TITLE
Add Install service section

### DIFF
--- a/templates/systemd-system-cadvisor-service.j2
+++ b/templates/systemd-system-cadvisor-service.j2
@@ -4,3 +4,6 @@ Description=Cadvisor Server
 [Service]
 #User=root
 ExecStart=/opt/cadvisor/cadvisor --port {{ cadvisor_port | default(9280) }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is required for `systemctl enable`, otherwise the service will not be started after a reboot.