### PR TITLE
Allow: cadvisor download url override, runtime options and version bump

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 # Version
-cadvisor_version: v0.29.0
+cadvisor_version: v0.32.0
 
 # SHA256 checksum
-cadvisor_checksum: f5c8deb31eb12cae38007f0f4a208e0b9ba2b2ad6a1c9610b32d113221880d4e
+cadvisor_checksum: 62419c0e06edb55a9c02e68fcae3a81abac2a2d98122c36a9124259e0ca8916c
 
 # Listen port
 cadvisor_port: 9280

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,3 @@ cadvisor_download: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
 
 # Extra runtime options
 cadvisor_runtime_options: ""
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,6 @@ cadvisor_checksum: f5c8deb31eb12cae38007f0f4a208e0b9ba2b2ad6a1c9610b32d113221880
 
 # Listen port
 cadvisor_port: 9280
+
+# Download url
+cadvisor_url: https://github.com/google/cadvisor/releases/download/{{ cadvisor_version }}/cadvisor

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ cadvisor_port: 9280
 cadvisor_url: https://github.com/google/cadvisor/releases/download/
 
 # Download url
-cadvisor_download: {{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor
+cadvisor_download: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
 
 # Extra runtime options
 cadvisor_runtime_options: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,12 @@ cadvisor_checksum: 62419c0e06edb55a9c02e68fcae3a81abac2a2d98122c36a9124259e0ca89
 # Listen port
 cadvisor_port: 9280
 
+# Base cadvisor url
+cadvisor_url: https://github.com/google/cadvisor/releases/download/
+
 # Download url
-cadvisor_url: https://github.com/google/cadvisor/releases/download/{{ cadvisor_version }}/cadvisor
+cadvisor_download: {{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor
 
 # Extra runtime options
 cadvisor_runtime_options: ""
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,6 @@ cadvisor_port: 9280
 
 # Download url
 cadvisor_url: https://github.com/google/cadvisor/releases/download/{{ cadvisor_version }}/cadvisor
+
+# Extra runtime options
+cadvisor_runtime_options: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,4 +46,3 @@
     enabled: yes
     name: cadvisor.service
     state: started
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: cadvisor | download
   become: yes
   get_url:
-    url: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
+    url: "{{ cadvisor_url }}"
     checksum: "sha256:{{ cadvisor_checksum }}"
     dest: "/opt/cadvisor/cadvisor-{{ cadvisor_version }}"
     force: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: cadvisor | download
   become: yes
   get_url:
-    url: "{{ cadvisor_url }}"
+    url: "{{ cadvisor_download }}"
     checksum: "sha256:{{ cadvisor_checksum }}"
     dest: "/opt/cadvisor/cadvisor-{{ cadvisor_version }}"
     force: no
@@ -46,3 +46,4 @@
     enabled: yes
     name: cadvisor.service
     state: started
+

--- a/templates/systemd-system-cadvisor-service.j2
+++ b/templates/systemd-system-cadvisor-service.j2
@@ -3,7 +3,7 @@ Description=Cadvisor Server
 
 [Service]
 #User=root
-ExecStart=/opt/cadvisor/cadvisor --port {{ cadvisor_port }}
+ExecStart=/opt/cadvisor/cadvisor --port {{ cadvisor_port }} {{ cadvisor_runtime_options }}
 
 [Install]
 WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
-# Download url
-cadvisor_url: https://github.com/google/cadvisor/releases/download/


### PR DESCRIPTION
Changes:

* Ability to override the cadvisor download url (still defaults to github with old format)
* Bumped default cadvisor version from v0.29.0 to [v0.32.0](https://github.com/google/cadvisor/releases/tag/v0.32.0)
* Added ability to pass [runtime options](https://github.com/google/cadvisor/blob/master/docs/runtime_options.md) to cadviser on service start 

e.g. 
```
  include_role:
    name: ansible-role-cadvisor
  vars:
    cadvisor_port: "10002"
    cadvisor_url: ""https://example.com/my-copy-of-cadvisor"
    cadvisor_version: "v0.32.0"
    cadvisor_runtime_options: >
      --enable_load_reader=true
      --disable_metrics=tcp,udp,sched
      --storage_duration=2m0s
      --prometheus_endpoint="/metrics"

```