### PR TITLE
feat: add cpuarch download support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,16 @@
 ---
 # Version
-cadvisor_version: v0.32.0
+cadvisor_version: v0.45.0
 
 # CPU Architecture
-cadvisor_cpu_arch: ""
+cadvisor_cpu_arch: "linux-amd64"
 
 # Cadvisor source path if offline
 cadvisor_binary_local_dir: ""
 
 # SHA256 checksum
 cadvisor_checksum: >-
-  62419c0e06edb55a9c02e68fcae3a81abac2a2d98122c36a9124259e0ca8916c
+  9a2a0b69f58d932855c0af23b847cb9de8f8c32264f66f9fb5dcc8f359f34ccd
 
 # Listen port
 cadvisor_port: 9280

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,8 @@
 cadvisor_version: v0.45.0
 
 # CPU Architecture
-cadvisor_cpu_arch: "linux-amd64"
+# Empty string "" for all versions < v0.45.0
+cadvisor_binary_suffix: "-{{ cadvisor_version }}-linux-amd64"
 
 # Cadvisor source path if offline
 cadvisor_binary_local_dir: ""
@@ -19,9 +20,8 @@ cadvisor_port: 9280
 cadvisor_url: https://github.com/google/cadvisor/releases/download/
 
 # Download url
-cadvisor_download_no_arch: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
-cadvisor_download_multi_arch: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor-{{ cadvisor_version }}-{{ cadvisor_cpu_arch }}"
-cadvisor_download: "{{ lookup('vars', 'cadvisor_download_no_arch') if (cadvisor_cpu_arch | length == 0) else lookup('vars','cadvisor_download_multi_arch') }}"
+cadvisor_download: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor\
+  {{ cadvisor_binary_suffix }}"
 
 # Extra runtime options
 cadvisor_runtime_options: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Version
 cadvisor_version: v0.32.0
 
+# CPU Architecture
+cadvisor_cpu_arch: ""
+
 # Cadvisor source path if offline
 cadvisor_binary_local_dir: ""
 
@@ -16,7 +19,9 @@ cadvisor_port: 9280
 cadvisor_url: https://github.com/google/cadvisor/releases/download/
 
 # Download url
-cadvisor_download: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
+cadvisor_download_no_arch: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor"
+cadvisor_download_multi_arch: "{{ cadvisor_url }}/{{ cadvisor_version }}/cadvisor-{{ cadvisor_version }}-{{ cadvisor_cpu_arch }}"
+cadvisor_download: "{{ lookup('vars', 'cadvisor_download_no_arch') if (cadvisor_cpu_arch | length == 0) else lookup('vars','cadvisor_download_multi_arch') }}"
 
 # Extra runtime options
 cadvisor_runtime_options: ""


### PR DESCRIPTION
With the release of cadvisor [v0.45.0](https://github.com/google/cadvisor/releases/tag/v0.45.0), this playbook can no longer download the latest binaries. This is a result of the new release providing support for multiple CPU architectures and the corresponding change in the binary name in the download URL.

Changes:
- Add `cadvisor_cpu_arch` for specifying CPU architecture of latest versions of cadvisor
- Allow `cadvisor_download` to be derived based on value of `cadvisor_cpu_arch`
- Update default `cadvisor_version` to [v0.45.0](https://github.com/google/cadvisor/releases/tag/v0.45.0) along with the `cadvisor_checksum` for the `linux-amd64` version of the binary.

```
include_role:
  name: ansible-role-cadvisor
vars:
  cadvisor_version: v0.45.0
  cadvisor_cpu_arch: "linux-amd64"
  cadvisor_checksum: 9a2a0b69f58d932855c0af23b847cb9de8f8c32264f66f9fb5dcc8f359f34ccd
```

If you would prefer that the `cadvisor_version` and `cadvisor_checksum` not be bumped as a part of this PR, I can revert that change and set `cadvisor_cpu_arch` to "" which would allow in place updates to the role without requiring use of cadvisor v0.45.0 or higher.