### PR TITLE
Fix molecule idempotence tests

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,8 @@
     name: cadvisor
     state: restarted
     daemon_reload: true
+
+- name: reload systemd units
+  become: true
+  systemd:
+    daemon_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,8 +7,3 @@
     name: cadvisor
     state: restarted
     daemon_reload: true
-
-- name: reload systemd units
-  become: true
-  systemd:
-    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,6 @@
     mode: 0644
   notify:
     - restart cadvisor
-    - reload systemd units
 
 - name: cadvisor | enable and start server systemd
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     mode: 0644
   notify:
     - restart cadvisor
+    - reload systemd units
 
 - name: cadvisor | enable and start server systemd
   become: true
@@ -54,4 +55,3 @@
     enabled: true
     name: cadvisor.service
     state: started
-    daemon_reload: true


### PR DESCRIPTION
The current molecule tests are not idempotent because they always reload systemd even when no changes are made to the systemd units. This forces the role to reload it only when necessary.

Once this is tested and merged, it should unblock https://github.com/ome/ansible-role-cadvisor/pull/8 so that the role can support newer versions of cadvisor too. That PR is not failing because of anything actually in that PR.